### PR TITLE
Add configurable 2048 game with customizable tiles

### DIFF
--- a/lib/game_board.dart
+++ b/lib/game_board.dart
@@ -1,0 +1,108 @@
+import 'dart:math';
+import 'package:flutter/material.dart';
+import 'game_manager.dart';
+
+/// Widget that renders the game board and handles user interaction.
+class GameBoard extends StatelessWidget {
+  const GameBoard({super.key, required this.game});
+
+  final GameManager game;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onVerticalDragEnd: (details) {
+        if (details.primaryVelocity == null) return;
+        if (details.primaryVelocity! < 0) {
+          game.move(Direction.up);
+        } else {
+          game.move(Direction.down);
+        }
+      },
+      onHorizontalDragEnd: (details) {
+        if (details.primaryVelocity == null) return;
+        if (details.primaryVelocity! < 0) {
+          game.move(Direction.left);
+        } else {
+          game.move(Direction.right);
+        }
+      },
+      child: AspectRatio(
+        aspectRatio: 1,
+        child: GridView.builder(
+          physics: const NeverScrollableScrollPhysics(),
+          padding: const EdgeInsets.all(8),
+          itemCount: game.size * game.size,
+          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+            crossAxisCount: game.size,
+            crossAxisSpacing: 4,
+            mainAxisSpacing: 4,
+          ),
+          itemBuilder: (context, index) {
+            final x = index ~/ game.size;
+            final y = index % game.size;
+            final value = game.board[x][y];
+            return _Tile(value: value, mode: game.mode);
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _Tile extends StatelessWidget {
+  const _Tile({required this.value, required this.mode});
+
+  final int value;
+  final TileMode mode;
+
+  Color _colorForValue(int value) {
+    final int pow = (log(value) / log(2)).toInt();
+    final List<Color> colors = [
+      Colors.grey.shade300,
+      Colors.lightBlue.shade100,
+      Colors.lightBlue.shade200,
+      Colors.lightBlue.shade300,
+      Colors.lightBlue.shade400,
+      Colors.lightBlue.shade500,
+      Colors.lightBlue.shade600,
+      Colors.lightBlue.shade700,
+      Colors.lightBlue.shade800,
+      Colors.lightBlue.shade900,
+    ];
+    return colors[pow.clamp(0, colors.length - 1)];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (value == 0) {
+      return Container(color: Colors.grey.shade200);
+    }
+    final index = (log(value) / log(2)).toInt() - 1;
+    Widget child;
+    switch (mode) {
+      case TileMode.numbers:
+        child = Text(
+          '$value',
+          style: Theme.of(context)
+              .textTheme
+              .headlineMedium!
+              .copyWith(color: Colors.black),
+        );
+        break;
+      case TileMode.icons:
+        child = Icon(TileSets.icons[index % TileSets.icons.length]);
+        break;
+      case TileMode.pictures:
+        child = Image.network(
+          'https://picsum.photos/200?image=${index + 10}',
+          fit: BoxFit.cover,
+        );
+        break;
+    }
+    return Container(
+      color: _colorForValue(value),
+      child: Center(child: child),
+    );
+  }
+}

--- a/lib/game_manager.dart
+++ b/lib/game_manager.dart
@@ -1,0 +1,194 @@
+import 'dart:math';
+import 'package:flutter/material.dart';
+
+/// Enum describing different display modes for tiles.
+enum TileMode { numbers, icons, pictures }
+
+/// Directions the board can be moved in.
+enum Direction { up, down, left, right }
+
+/// Core 2048 game logic with customizable board size and tile style.
+class GameManager extends ChangeNotifier {
+  GameManager({this.size = 4, this.mode = TileMode.numbers}) {
+    _initBoard();
+  }
+
+  int size;
+  TileMode mode;
+
+  late List<List<int>> _board;
+  final Random _rng = Random();
+
+  List<List<int>> get board => _board;
+
+  /// Starts a new game.
+  void newGame({int? newSize}) {
+    if (newSize != null) {
+      size = newSize;
+    }
+    _initBoard();
+    notifyListeners();
+  }
+
+  void setMode(TileMode newMode) {
+    mode = newMode;
+    notifyListeners();
+  }
+
+  void _initBoard() {
+    _board = List.generate(size, (_) => List.filled(size, 0));
+    _spawnTile();
+    _spawnTile();
+  }
+
+  bool move(Direction dir) {
+    bool moved = false;
+    switch (dir) {
+      case Direction.left:
+        moved = _moveLeft();
+        break;
+      case Direction.right:
+        moved = _moveRight();
+        break;
+      case Direction.up:
+        moved = _moveUp();
+        break;
+      case Direction.down:
+        moved = _moveDown();
+        break;
+    }
+    if (moved) {
+      _spawnTile();
+      notifyListeners();
+    }
+    return moved;
+  }
+
+  bool _moveLeft() {
+    bool moved = false;
+    for (int i = 0; i < size; i++) {
+      List<int> row = _board[i];
+      List<int> merged = _merge(_compress(row));
+      if (!_listEquals(row, merged)) {
+        _board[i] = merged;
+        moved = true;
+      }
+    }
+    return moved;
+  }
+
+  bool _moveRight() {
+    bool moved = false;
+    for (int i = 0; i < size; i++) {
+      List<int> row = List.from(_board[i].reversed);
+      List<int> merged = _merge(_compress(row));
+      merged = merged.reversed.toList();
+      if (!_listEquals(_board[i], merged)) {
+        _board[i] = merged;
+        moved = true;
+      }
+    }
+    return moved;
+  }
+
+  bool _moveUp() {
+    bool moved = false;
+    for (int j = 0; j < size; j++) {
+      List<int> column = List.generate(size, (i) => _board[i][j]);
+      List<int> merged = _merge(_compress(column));
+      for (int i = 0; i < size; i++) {
+        if (_board[i][j] != merged[i]) {
+          _board[i][j] = merged[i];
+          moved = true;
+        }
+      }
+    }
+    return moved;
+  }
+
+  bool _moveDown() {
+    bool moved = false;
+    for (int j = 0; j < size; j++) {
+      List<int> column = List.generate(size, (i) => _board[i][j]).reversed.toList();
+      List<int> merged = _merge(_compress(column));
+      merged = merged.reversed.toList();
+      for (int i = 0; i < size; i++) {
+        if (_board[i][j] != merged[i]) {
+          _board[i][j] = merged[i];
+          moved = true;
+        }
+      }
+    }
+    return moved;
+  }
+
+  List<int> _compress(List<int> line) {
+    line.removeWhere((v) => v == 0);
+    while (line.length < size) {
+      line.add(0);
+    }
+    return line;
+  }
+
+  List<int> _merge(List<int> line) {
+    for (int i = 0; i < line.length - 1; i++) {
+      if (line[i] != 0 && line[i] == line[i + 1]) {
+        line[i] *= 2;
+        line.removeAt(i + 1);
+        line.add(0);
+      }
+    }
+    return line;
+  }
+
+  bool _listEquals(List<int> a, List<int> b) {
+    if (a.length != b.length) return false;
+    for (int i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) return false;
+    }
+    return true;
+  }
+
+  void _spawnTile() {
+    List<Point<int>> empty = [];
+    for (int i = 0; i < size; i++) {
+      for (int j = 0; j < size; j++) {
+        if (_board[i][j] == 0) empty.add(Point(i, j));
+      }
+    }
+    if (empty.isEmpty) return;
+    Point<int> p = empty[_rng.nextInt(empty.length)];
+    _board[p.x][p.y] = _rng.nextInt(10) == 0 ? 4 : 2;
+  }
+
+  bool get hasMoves {
+    for (int i = 0; i < size; i++) {
+      for (int j = 0; j < size; j++) {
+        if (_board[i][j] == 0) return true;
+        if (i < size - 1 && _board[i][j] == _board[i + 1][j]) return true;
+        if (j < size - 1 && _board[i][j] == _board[i][j + 1]) return true;
+      }
+    }
+    return false;
+  }
+}
+
+/// Predefined icon sets used for icon/picture modes.
+class TileSets {
+  static const List<IconData> icons = [
+    Icons.filter_1,
+    Icons.filter_2,
+    Icons.filter_3,
+    Icons.filter_4,
+    Icons.filter_5,
+    Icons.filter_6,
+    Icons.filter_7,
+    Icons.filter_8,
+    Icons.filter_9,
+    Icons.star,
+  ];
+
+  static const List<String> emojis = [
+    '🐶', '🐱', '🐭', '🐹', '🐰', '🦊', '🐻', '🐼', '🐨', '🐯'
+  ];
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'game_board.dart';
+import 'game_manager.dart';
 
 void main() {
   runApp(const MyApp());
@@ -7,116 +9,102 @@ void main() {
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+      title: '2048',
+      theme: ThemeData(colorScheme: ColorScheme.fromSeed(seedColor: Colors.indigo)),
+      home: const GamePage(),
     );
   }
 }
 
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
+class GamePage extends StatefulWidget {
+  const GamePage({super.key});
 
   @override
-  State<MyHomePage> createState() => _MyHomePageState();
+  State<GamePage> createState() => _GamePageState();
 }
 
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
+class _GamePageState extends State<GamePage> {
+  late GameManager _game;
+  int _size = 4;
+  TileMode _mode = TileMode.numbers;
 
-  void _incrementCounter() {
+  @override
+  void initState() {
+    super.initState();
+    _game = GameManager(size: _size, mode: _mode);
+  }
+
+  void _restart() {
     setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
+      _game = GameManager(size: _size, mode: _mode);
     });
   }
 
   @override
   Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
     return Scaffold(
       appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
+        title: const Text('2048'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            onPressed: _restart,
+          ),
+        ],
       ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                DropdownButton<int>(
+                  value: _size,
+                  items: List.generate(7, (i) => i + 2)
+                      .map((s) => DropdownMenuItem(value: s, child: Text('${s}x$s')))
+                      .toList(),
+                  onChanged: (v) {
+                    if (v == null) return;
+                    setState(() {
+                      _size = v;
+                      _game.newGame(newSize: _size);
+                    });
+                  },
+                ),
+                const SizedBox(width: 16),
+                DropdownButton<TileMode>(
+                  value: _mode,
+                  items: const [
+                    DropdownMenuItem(value: TileMode.numbers, child: Text('Numbers')),
+                    DropdownMenuItem(value: TileMode.icons, child: Text('Icons')),
+                    DropdownMenuItem(value: TileMode.pictures, child: Text('Pictures')),
+                  ],
+                  onChanged: (m) {
+                    if (m == null) return;
+                    setState(() {
+                      _mode = m;
+                      _game.setMode(m);
+                    });
+                  },
+                ),
+              ],
             ),
-          ],
-        ),
+          ),
+          Expanded(
+            child: AnimatedBuilder(
+              animation: _game,
+              builder: (context, _) => Center(
+                child: GameBoard(game: _game),
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+        ],
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
     );
   }
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,25 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
 import 'package:twenty_forty_eight/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
+  testWidgets('Board resizes correctly', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
+    // initial board size 4x4
+    expect(find.byType(GridView), findsOneWidget);
+    expect(find.byType(GestureDetector), findsOneWidget);
 
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
+    // there should be 16 tiles
+    expect(find.byType(Container), findsWidgets);
 
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // Change board size to 5x5
+    await tester.tap(find.byType(DropdownButton<int>).first);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('5x5').last);
+    await tester.pumpAndSettle();
+
+    // board should rebuild
+    expect(find.byType(GridView), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- Implement core 2048 logic with dynamic board sizing and tile modes
- Add gesture-driven game board that supports numbers, icons or pictures for tiles
- Update main app and widget tests for new 2048 gameplay

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1da8f6088832784c9e048c939cd4f